### PR TITLE
add dgml output support

### DIFF
--- a/source/Ninject.FeatureDumper/BindingReader.cs
+++ b/source/Ninject.FeatureDumper/BindingReader.cs
@@ -1,0 +1,77 @@
+﻿// <copyright file="BindingReader.cs" company="Ninject.Features">
+//   Copyright (c)  2013-2015
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+
+namespace Ninject.FeatureDumper
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Reflection;
+    using Activation;
+    using Infrastructure;
+    using Modules;
+    using Planning.Bindings;
+
+    public class BindingReader
+    {
+        public List<FeatureInfo> GetBindingInformations(INinjectModule module)
+        {
+            List<FeatureInfo> bindingsFeatureInfoList = new List<FeatureInfo>();
+
+            IKernel kernel = new StandardKernel();
+            module.OnLoad(kernel);
+
+            List<KeyValuePair<Type, ICollection<IBinding>>> typeBindingInfo = GetBindings(kernel, module.Name);
+
+            foreach (KeyValuePair<Type, ICollection<IBinding>> typeBinding in typeBindingInfo)
+            {
+                FeatureInfo bindingInterface = new FeatureInfo(typeBinding.Key, null, null, FeatureType.BindingInterface);
+
+                foreach (IBinding binding in typeBinding.Value)
+                {
+                    ContextMock contextMock = new ContextMock(kernel);
+
+                    IProvider provider = binding.ProviderCallback(contextMock);
+
+                    FeatureInfo bindingInterfaceImpl = new FeatureInfo(provider.Type, null, null, FeatureType.BindingImpl);
+                    bindingInterfaceImpl.SetBindingType(binding.Target);
+
+                    bindingInterface.AddDependency(bindingInterfaceImpl);
+                }
+
+                bindingsFeatureInfoList.Add(bindingInterface);
+            }
+
+            return bindingsFeatureInfoList;
+        }
+
+        private List<KeyValuePair<Type, ICollection<IBinding>>> GetBindings(IKernel kernel, string moduleName)
+        {
+            string firstPartofModuleName = moduleName.Substring(0, moduleName.IndexOfAny(new[] {'.'}) + 1);
+
+            List<KeyValuePair<Type, ICollection<IBinding>>> returnvalue = ((Multimap<Type, IBinding>)
+                typeof(KernelBase).GetField("bindings", BindingFlags.NonPublic | BindingFlags.Instance)
+                .GetValue(kernel))
+                .Where(k => k.Key.FullName.StartsWith(firstPartofModuleName))
+                .ToList();
+
+            return returnvalue;
+        }
+
+
+    }
+}

--- a/source/Ninject.FeatureDumper/ContextMock.cs
+++ b/source/Ninject.FeatureDumper/ContextMock.cs
@@ -1,0 +1,104 @@
+﻿// <copyright file="ContextMock.cs" company="Ninject.Features">
+//   Copyright (c)  2013-2015
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+
+namespace Ninject.FeatureDumper
+{
+    using System;
+    using System.Collections.Generic;
+    using Activation;
+    using Parameters;
+    using Planning;
+    using Planning.Bindings;
+
+
+    public class ContextMock : IContext
+    {
+        public ContextMock(IKernel kernel)
+        {
+            this.Kernel = kernel;
+        }
+
+        public IProvider GetProvider()
+        {
+            throw new NotImplementedException();
+        }
+
+        public object GetScope()
+        {
+            throw new NotImplementedException();
+        }
+
+        public object Resolve()
+        {
+            throw new NotImplementedException();
+        }
+
+        public IKernel Kernel { get; private set; }
+
+        public IRequest Request
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public IBinding Binding
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public IPlan Plan
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+            set
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public ICollection<IParameter> Parameters
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public Type[] GenericArguments
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+
+        public bool HasInferredGenericArguments
+        {
+            get
+            {
+                throw new NotImplementedException();
+            }
+        }
+    }
+}

--- a/source/Ninject.FeatureDumper/DgmlWriter/ColorSelector.cs
+++ b/source/Ninject.FeatureDumper/DgmlWriter/ColorSelector.cs
@@ -1,0 +1,74 @@
+﻿// <copyright file="ColorSelector.cs" company="Ninject.Features">
+//   Copyright (c)  2013-2015
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+
+namespace Ninject.FeatureDumper.DgmlWriter
+{
+    public class ColorSelector
+    {
+        public string GetBackgroundColor(FeatureType featureType)
+        {
+            DgmlColorConfiguration dgmlColor = new DgmlColorConfiguration();
+            string color = string.Empty;
+            switch (featureType)
+            {
+                case FeatureType.Feature:
+                case FeatureType.NeededFeature:
+                    color = dgmlColor.FeatureColor;
+                    break;
+                case FeatureType.NeededExtensions:
+                case FeatureType.Module:
+                    color = dgmlColor.ModuleColor;
+                    break;
+                case FeatureType.BindingInterface:
+                    color = dgmlColor.BindingInterfaceColor;
+                    break;
+                case FeatureType.BindingImpl:
+                    color = dgmlColor.BindingImplColor;
+                    break;
+            }
+
+            return color;
+        }
+
+        public string GetLinkColor(FeatureType featureType)
+        {
+            DgmlColorConfiguration dgmlColor = new DgmlColorConfiguration();
+            string color = string.Empty;
+            switch (featureType)
+            {
+                case FeatureType.Feature:
+                case FeatureType.NeededFeature:
+                    color = dgmlColor.FeatureColor;
+                    break;
+                case FeatureType.NeededExtensions:
+                    color = dgmlColor.NeededExtensionsColor;
+                    break;
+                case FeatureType.Module:
+                    color = dgmlColor.ModuleColor;
+                    break;
+                case FeatureType.BindingInterface:
+                    color = dgmlColor.BindingInterfaceColor;
+                    break;
+                case FeatureType.BindingImpl:
+                    color = dgmlColor.BindingImplColor;
+                    break;
+            }
+
+            return color;
+        }
+    }
+}

--- a/source/Ninject.FeatureDumper/DgmlWriter/DgmlColorConfiguration.cs
+++ b/source/Ninject.FeatureDumper/DgmlWriter/DgmlColorConfiguration.cs
@@ -1,0 +1,32 @@
+﻿// <copyright file="DgmlColorConfiguration.cs" company="Ninject.Features">
+//   Copyright (c)  2013-2015
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+
+namespace Ninject.FeatureDumper.DgmlWriter
+{
+    public class DgmlColorConfiguration
+    {
+        public string FeatureColor => "#0094FF";
+
+        public string NeededExtensionsColor => "#FF0000";
+
+        public string ModuleColor => "#C0C0C0";
+
+        public string BindingInterfaceColor => "#00E21A";
+
+        public string BindingImplColor => "#FFB626";
+    }
+}

--- a/source/Ninject.FeatureDumper/DgmlWriter/DgmlProcessor.cs
+++ b/source/Ninject.FeatureDumper/DgmlWriter/DgmlProcessor.cs
@@ -1,0 +1,98 @@
+﻿// <copyright file="DgmlProcessor.cs" company="Ninject.Features">
+//   Copyright (c)  2013-2015
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+
+namespace Ninject.FeatureDumper.DgmlWriter
+{
+    using System.Collections.Generic;
+    using System.Linq;
+    using System.Xml.Linq;
+    using Appccelerate.IO;
+
+    public class DgmlProcessor
+    {
+        private readonly List<FeatureInfo> workedFeatureInfo = new List<FeatureInfo>();
+        private readonly List<XElement> nodes = new List<XElement>();
+        private readonly List<XElement> links = new List<XElement>();
+
+        private readonly XNamespace nameSpace = "http://schemas.microsoft.com/vs/2009/dgml";
+
+        private readonly XElementCreater elementCreater;
+
+        public DgmlProcessor()
+        {
+            this.elementCreater = new XElementCreater(this.nameSpace, new ColorSelector());
+        }
+
+        public void Write(Features features, AbsoluteFilePath fulldgmlFileName)
+        {
+            var list = new List<FeatureInfo>(features.AllFeatures);
+            foreach (FeatureInfo featureInfo in list.OrderBy(x => x.FeatureType))
+            {
+                this.HandleNode(featureInfo, string.Empty);
+            }
+
+            this.WriteDgml(fulldgmlFileName);
+        }
+
+        private void HandleNode(FeatureInfo featureInfo, string sourceElementId)
+        {
+            FeatureInfo existingFeatureInfo = this.workedFeatureInfo.SingleOrDefault(x => x.UniqueName == featureInfo.UniqueName);
+            if (existingFeatureInfo != null)
+            {
+                if (!string.IsNullOrEmpty(sourceElementId))
+                {
+                    XElement link = this.elementCreater.GenerateLink(sourceElementId, existingFeatureInfo, featureInfo.FeatureType);
+                    this.links.Add(link);
+
+                    this.HandleFeatureDependencies(featureInfo, existingFeatureInfo.Id);
+                }
+            }
+            else
+            {
+                XElement node = this.elementCreater.GenerateNode(featureInfo);
+                this.nodes.Add(node);
+
+                XElement link = this.elementCreater.GenerateLink(sourceElementId, featureInfo, featureInfo.FeatureType);
+                this.links.Add(link);
+
+                this.workedFeatureInfo.Add(featureInfo);
+
+                HandleFeatureDependencies(featureInfo, featureInfo.Id);
+            }
+        }
+
+        private void HandleFeatureDependencies(FeatureInfo featureInfo, string sourceElementId)
+        {
+            foreach (FeatureInfo dependency in featureInfo.DependenciesInfo)
+            {
+                HandleNode(dependency, sourceElementId);
+            }
+        }
+
+        private void WriteDgml(AbsoluteFilePath fulldgmlFileName)
+        {
+            var documentFinal = new XDocument(
+                new XDeclaration("1.0", "utf-8", string.Empty),
+                new XElement(
+                    this.nameSpace + "DirectedGraph",
+                    new XElement(this.nameSpace + "Nodes", this.nodes),
+                    new XElement(this.nameSpace + "Links", this.links)));
+
+            documentFinal.Save(fulldgmlFileName);
+        }
+    }
+}

--- a/source/Ninject.FeatureDumper/DgmlWriter/XElementCreater.cs
+++ b/source/Ninject.FeatureDumper/DgmlWriter/XElementCreater.cs
@@ -1,0 +1,66 @@
+﻿// <copyright file="XElementCreater.cs" company="Ninject.Features">
+//   Copyright (c)  2013-2015
+//
+//   Licensed under the Apache License, Version 2.0 (the "License");
+//
+//   you may not use this file except in compliance with the License.
+//   You may obtain a copy of the License at
+//
+//       http://www.apache.org/licenses/LICENSE-2.0
+//
+//   Unless required by applicable law or agreed to in writing, software
+//   distributed under the License is distributed on an "AS IS" BASIS,
+//   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//   See the License for the specific language governing permissions and
+//   limitations under the License.
+// </copyright>
+
+namespace Ninject.FeatureDumper.DgmlWriter
+{
+    using System.Xml.Linq;
+
+    public class XElementCreater
+    {
+        private readonly ColorSelector colorSelector;
+        private readonly XNamespace nameSpace;
+
+        public XElementCreater(XNamespace xNamespace, ColorSelector colorSelector)
+        {
+            this.nameSpace = xNamespace;
+            this.colorSelector = colorSelector;
+        }
+
+        public XElement GenerateNode(FeatureInfo featureInfo)
+        {
+            string color = this.colorSelector.GetBackgroundColor(featureInfo.FeatureType);
+            var node = new XElement(
+                this.nameSpace + "Node",
+                new XAttribute("Id", featureInfo.Id),
+                new XAttribute("Label", featureInfo.Name),
+                new XAttribute("Background", color),
+                new XAttribute("Category", featureInfo.AssemblyName));
+
+            return node;
+        }
+
+        public XElement GenerateLink(string sourceElementId, FeatureInfo targetElement, FeatureType featureType)
+        {
+            string color = this.colorSelector.GetLinkColor(featureType);
+
+            XAttribute label =
+                string.IsNullOrEmpty(targetElement.BindingTarget.ToString())
+                ? new XAttribute("Label", featureType)
+                : new XAttribute("Label", "Binding " + targetElement.BindingTarget);
+
+            var link = new XElement(
+                this.nameSpace + "Link",
+                new XAttribute("Source", sourceElementId),
+                new XAttribute("Target", targetElement.Id),
+                new XAttribute("Stroke", color),
+                new XAttribute("StrokeDashArray", "3"),
+                label);
+
+            return link;
+        }
+    }
+}

--- a/source/Ninject.FeatureDumper/Ninject.FeatureDumper.csproj
+++ b/source/Ninject.FeatureDumper/Ninject.FeatureDumper.csproj
@@ -60,6 +60,10 @@
       <HintPath>..\packages\Appccelerate.IO.2.15.0\lib\net45\Appccelerate.IO.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="Ninject, Version=3.2.0.0, Culture=neutral, PublicKeyToken=c7192dc5380945e7, processorArchitecture=MSIL">
+      <HintPath>..\packages\Ninject.3.2.2.0\lib\net45-full\Ninject.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
     <Reference Include="NullGuard, Version=1.4.4.0, Culture=neutral, PublicKeyToken=1958ac8092168428, processorArchitecture=MSIL">
       <HintPath>..\packages\NullGuard.Fody.1.4.4\lib\dotnet\NullGuard.dll</HintPath>
       <Private>False</Private>
@@ -73,6 +77,12 @@
   <ItemGroup>
     <Compile Include="AssemblyLoader.cs" />
     <Compile Include="AssemblyResolveHandler.cs" />
+    <Compile Include="BindingReader.cs" />
+    <Compile Include="ContextMock.cs" />
+    <Compile Include="DgmlWriter\ColorSelector.cs" />
+    <Compile Include="DgmlWriter\DgmlColorConfiguration.cs" />
+    <Compile Include="DgmlWriter\DgmlProcessor.cs" />
+    <Compile Include="DgmlWriter\XElementCreater.cs" />
     <Compile Include="FeatureProcessor.cs" />
     <Compile Include="Features.cs" />
     <Compile Include="Program.cs" />

--- a/source/Ninject.FeatureDumper/Program.cs
+++ b/source/Ninject.FeatureDumper/Program.cs
@@ -22,6 +22,8 @@ namespace Ninject.FeatureDumper
 
     using Appccelerate.CommandLineParser;
     using Appccelerate.IO;
+    using System.IO;
+    using DgmlWriter;
 
     public static class Program
     {
@@ -34,6 +36,7 @@ namespace Ninject.FeatureDumper
                 bool includeFactories = false;
                 bool includeDependencies = false;
                 AbsoluteFilePath yedPath = @"C:\Program Files (x86)\yWorks\yEd\yEd.exe";
+                string outputFormat = "tgf";
 
                 CommandLineConfiguration commandLineConfiguration = CommandLineParserConfigurator
                     .Create()
@@ -49,6 +52,8 @@ namespace Ninject.FeatureDumper
                             .DescribedBy("Include information about feature dependencies.")
                         .WithNamed("-yed", path => yedPath = path)
                             .DescribedBy("yEd path", @"Path specifing location of yEd. If not specified, the default installation path is used (C:\Program Files (x86)\yWorks\yEd\yEd.exe).")
+                        .WithNamed("format", format => outputFormat = format)
+                            .DescribedBy("format", @"Format define dgml or tfg output. The default is tgf. File extension will automatical change to dgml")
                     .BuildConfiguration();
 
                 var parser = new CommandLineParser(commandLineConfiguration);
@@ -67,10 +72,19 @@ namespace Ninject.FeatureDumper
                 var featureProcessor = new FeatureProcessor();
                 Features features = featureProcessor.ProcessAssemblies(assemblies);
 
-                var tgfWriter = new TgfWriter();
-                tgfWriter.WriteTgfFile(outputPath, features, includeFactories, includeDependencies);
+                if (outputFormat.ToLower() == "dgml")
+                {
+                    outputPath = Path.ChangeExtension(outputPath, ".dgml");
+                    DgmlProcessor dgmlProcessor = new DgmlProcessor();
+                    dgmlProcessor.Write(features, outputPath);
+                }
+                else
+                {
+                    var tgfWriter = new TgfWriter();
+                    tgfWriter.WriteTgfFile(outputPath, features, includeFactories, includeDependencies);
 
-                StartYEd(yedPath, outputPath);
+                    StartYEd(yedPath, outputPath);
+                }
 
                 Console.WriteLine("done output file is " + outputPath);
             }

--- a/source/Ninject.FeatureDumper/packages.config
+++ b/source/Ninject.FeatureDumper/packages.config
@@ -8,6 +8,7 @@
   <package id="Appccelerate.IO" version="2.15.0" targetFramework="net46" />
   <package id="Appccelerate.VersionTask" version="1.22.0" targetFramework="net46" developmentDependency="true" />
   <package id="Fody" version="1.29.3" targetFramework="net46" developmentDependency="true" />
+  <package id="Ninject" version="3.2.2.0" targetFramework="net46" />
   <package id="NullGuard.Fody" version="1.4.4" targetFramework="net46" developmentDependency="true" />
   <package id="StyleCop.Analyzers" version="1.0.0-beta015" targetFramework="net46" developmentDependency="true" />
 </packages>


### PR DESCRIPTION
Hallo Urs, habe den Dgml Support eingebaut. Die CommandLineConfiguration kann man sicherlich besser machen. Bei Auslesen der Bindings im BindingReader muss ich in der Methode GetBindings alle automatischen Bindings (die ganzen Func<>) ausschließen. Daher prüfe ich jetzt auch den ersten Teil des FullNames. Ich hätte lieber nach dem erzeugen des StandardKernel die automatisch erzeugten Bindings gelöscht. Habe ich aber leider nicht hinbekommen.

Danke, dass ich mitarbeiten darf

Gruß
Dominik
